### PR TITLE
parser : allow last statement of a block to have a semicolon

### DIFF
--- a/bin/parser.mly
+++ b/bin/parser.mly
@@ -195,6 +195,7 @@ left :
 
 statement_seq : 
 | s = single_statement {s}
+| s = single_statement SEMICOLON {s}
 | s1 = left s2 = statement_seq {Seq(s1, s2)}
 | s1 = single_statement SEMICOLON s2 = statement_seq {Seq(s1,s2)}
 ;


### PR DESCRIPTION
Example :
```
{
    var x : int;
}
```