### PR TITLE
examples : fix syntax of the unsupported programs

### DIFF
--- a/examples/notSupported/accum.sl
+++ b/examples/notSupported/accum.sl
@@ -1,7 +1,7 @@
 process M(var i : int, o : int; signal s)
 {
 	while (true) {
-		await (s);
+		await s;
 		o = o + i;
 	}
 }
@@ -13,7 +13,7 @@ process N(var i : int, o : int; signal s)
 	while (true) {
 		if (x % 2 == 0) {
 			i = x;
-			emit (s);
+			emit s;
 		}
 		x = x + 1;
 	}
@@ -25,5 +25,5 @@ process Main() {
 	var o : int;
 	i = 0;
 	o = 0;
-	{M(i,o,s); || n(i,o,s);}
-}
+	{ M(i,o,s) || N(i,o,s)}
+} 

--- a/examples/notSupported/siglist.sl
+++ b/examples/notSupported/siglist.sl
@@ -14,25 +14,25 @@ struct node<A> {
 
 method length<A>(l : &list<A>) : int {
 	case (&l.head) {
-		None : return 0;
-		Some(node) : return 1 + length(node.next);
+		None : return 0,
+		Some(node) : return 1 + length(node.next)
 	}
 }
 
 method push<A>(l : &mut list<A>, elem : A) {
 	var node : node<int>;
-	node = {elem : elem; next : take(l.head)};
+	node = node { elem : elem, next : take(l.head) };
 	l.head = some(box(node));
 }
 
 process Pause(){
 	signal s1;
-	watching(s1){emit(s1); signal s2; when(s2){}}
+	watching s1 { emit s1 ; signal s2; when s2 {} }
 }
 
 process M(var x : &mut list<int>, y : &int ; signal s1,s2){
-	watching(s2){
-		when(s1) push(x, *y);
+	watching s2 {
+		when s1 push(x, *y);
 	}
 	return;
 }
@@ -41,18 +41,18 @@ process N(var x : &mut list<int>, y : &mut int; signal s1, s2){
 	var i : int;
 	i = 0;
 	while(i < 10){
-		emit(s1); 
+		emit s1; 
 		i = i + 1; 
 		*y = i; 
 		Pause();
 	}
-	emit(s2);
+	emit s2;
 }
 
 process Main(){
-	var x : &mut list<int> = {head : None};
+	var x : &mut list<int>;
 	var y : &mut int;
-	x = {head : None};
+	x = list {head : None};
 	y = 0;
 	signal s1;
 	signal s2;	


### PR DESCRIPTION
They are now able to be interpreted/compiled.

Note however the current version of the interpreter is unable to run them : 

- for accum.sl and siglist.sl it doesn't support running processes
- for list.sl, it errors out with the following : `ERROR : Undefined address 8`