### PR TITLE
sailor : type checker and generic methods/processes

### DIFF
--- a/bin/compiler/compiler_common.ml
+++ b/bin/compiler/compiler_common.ml
@@ -1,32 +1,110 @@
 open Llvm
 open Common
-open Sail_env
 
 type llvm_args = { c:llcontext; b:llbuilder;m:llmodule; }
 
-type statement_return = SailEnv.t * ( SailEnv.value option )
+type sailor_args = (string * sailtype) list
 
-let getLLVMType (t : sailtype) (llc: llcontext) (llm: llmodule) : lltype = 
+type sailor_decl = 
+{
+  ret : sailtype option;
+	args : sailor_args;
+}
+
+type sailor_method = (* both methods and processes for now *)
+{
+	decl : sailor_decl ;
+	body: Ast.statement;
+  generics : sailor_args
+}
+
+type sailor_process = 
+{
+  args : sailor_args;
+  body: Ast.statement;
+  generics : sailor_args
+}
+
+type varTypesMap = sailtype FieldMap.t List.t (* List is used for scoping *)
+
+type sailor_callables = {
+  methodMap : sailor_method FieldMap.t;
+  processMap : sailor_process FieldMap.t;
+    (* todo : structs & enum *)
+}
+
+type sailor_externals = (string * (sailor_decl * string list * (llvalue array -> llvm_args -> llvalue * llvalue array))) list
+
+let rec string_of_sailtype (t : sailtype option) : string =
+  let open Printf in 
+  match t with 
+  | Some Bool -> "bool"
+  | Some Int -> "int"
+  | Some Float -> "float"
+  | Some Char -> "char"
+  | Some String -> "string"
+  | Some ArrayType t -> sprintf "array<%s>" (string_of_sailtype (Some t))
+  | Some CompoundType (x, _tl) -> sprintf "%s<todo>" x
+  | Some Box(t) -> sprintf "ref<%s>" (string_of_sailtype (Some t))
+  | Some RefType (t,b) -> 
+      if b then sprintf "&mut %s" (string_of_sailtype (Some t))
+      else sprintf "& %s" (string_of_sailtype (Some t))
+  | Some GenericType(s) -> s
+  | None -> "void"
+
+
+let mangle_method_name (name:string) (args: sailtype list ) : string =
+  let back = List.fold_left (fun s t -> string_of_sailtype (Some t) ^ "_" ^ s) "" args in
+  let front = "_" ^ name ^ "_" in
+  let res = front ^ back in
+  Logs.debug (fun m -> m "renamed %s to %s" name res);
+  res
+
+
+let degenerifyType (t: sailtype) (generics: sailor_args) : sailtype =
+  let rec aux = function
+  | Bool -> Bool
+  | Int -> Int 
+  | Float -> Float
+  | Char -> Char
+  | String -> String
+  | ArrayType t -> ArrayType (aux t)
+  | CompoundType (_name, _tl)-> aux t
+  | Box t -> Box (aux t) 
+  | RefType (t,m) -> RefType (aux t, m)
+  | GenericType _ when generics = [] -> failwith "generic type preset but empty generics list"
+  | GenericType n -> 
+    begin
+      match List.assoc_opt n generics with
+      | Some t -> aux t
+      | None -> Printf.sprintf "generic type %s not present in the generics list" n |> failwith
+    end
+  in
+  aux t
+
+let getLLVMType (t : sailtype) (llc: llcontext) (_llm: llmodule) : lltype = 
   let rec aux = function
   | Bool -> i1_type llc
   | Int -> i32_type llc 
   | Float -> double_type llc
   | Char -> i8_type llc
   | String -> i8_type llc |> pointer_type
-  | ArrayType t -> aux t (* we just return the type of the elements *)
+  | ArrayType t -> aux t |> pointer_type
   | CompoundType (_, [t])-> aux t
   | CompoundType _-> failwith "compound type unimplemented"
   | Box _ -> failwith "boxing unimplemented" 
   | RefType (t,_) -> aux t |> pointer_type
-  | GenericType _ -> failwith "generic types unimplemented"
+  | GenericType _ -> failwith "there should be no generic type, was degenerifyType used ? " 
   in
   aux t
 
 
-let getLLVMValue (l:literal) (llvm:llvm_args) : llvalue =
+let getLLVMLiteral (l:literal) (llvm:llvm_args) : llvalue =
   match l with
   | LBool b -> const_int (i1_type llvm.c) (Bool.to_int b)
   | LInt i -> const_int (i32_type llvm.c) i
   | LFloat f -> const_float (double_type llvm.c) f
   | LChar c -> const_int (i8_type llvm.c) (Char.code c)
   | LString s -> build_global_stringptr  s ".str" llvm.b
+
+

--- a/bin/compiler/externals.ml
+++ b/bin/compiler/externals.ml
@@ -1,10 +1,11 @@
 open Llvm
 open Sail_env
 open Compiler_common
+open Common
 
 (* todo: simplify *)
 
-type exp_eval = SailEnv.t -> llvm_args -> Ast.expression ->  llvalue
+type exp_eval = SailEnv.t -> llvm_args -> Ast.expression -> llvalue
 let decl_printf (c:llcontext) : (llmodule -> llvalue) =
   let proto = var_arg_function_type (i32_type c) [|pointer_type (i8_type c)|] in
   declare_function "printf" proto
@@ -39,17 +40,26 @@ let _print_newline (args:llvalue array) (llvm:llvm_args) : llvalue  * llvalue ar
 let printf  (args:llvalue array) (llvm:llvm_args) : llvalue  * llvalue array =
   decl_printf llvm.c llvm.m, args
 
-  
 
-let external_methods (eval:exp_eval) (name : string) (args : Ast.expression list) (llvm:llvm_args) (env:SailEnv.t) : llvalue =
-  let args =  List.map (eval env llvm) args |> Array.of_list in
-  let method_builder =
-  match name with
-  | "print_string" -> _print_string
-  | "print_int" -> _print_int
-  | "print_newline" -> _print_newline
-  | "printf" -> printf
+let register_external name bind ret args generics ext_l  : sailor_externals = 
+  let args = List.mapi (fun i t -> (string_of_int i,t)) args  in
+  let decl : sailor_decl = {ret;args} in
+  (name,(decl,generics,bind))::ext_l
+
+
+let get_externals () : sailor_externals =
+  [] 
+  |> register_external "print_int" _print_int None [Int] []
+  |> register_external "print_newline" _print_newline None [] []
+  |> register_external "print_string" _print_string None [String] []
+  (* printf but only 2 args (no support for varargs) *)
+  |> register_external "printf" printf None [String; GenericType "T"] ["T"]
+
+let external_methods (name : string) (args : llvalue array) (llvm:llvm_args) (_env:SailEnv.t) : llvalue =
+  match List.assoc_opt name (get_externals ()) with
+  | Some (_,_,bind) -> 
+    let methd,args = bind args llvm in
+    build_call methd args "" llvm.b
   | _ -> failwith ("unknown external method " ^ name)
-  in 
-  let methd,args = method_builder args llvm in
-  build_call methd args "" llvm.b
+
+

--- a/bin/compiler/globals.ml
+++ b/bin/compiler/globals.ml
@@ -1,0 +1,55 @@
+open Common
+open Llvm
+open Compiler_common
+
+type function_value = {ret:sailtype option; proto:llvalue; (* generics:sailor_args *)}
+module type Globals = sig
+  type t =  function_value FieldMap.t
+  val get_declarations : sailor_callables -> llcontext -> llmodule -> t
+  val find_declaration : t -> string -> function_value option
+
+  val write_declarations : t -> string -> unit
+end
+
+  
+module Globals : Globals = struct
+  type t = function_value FieldMap.t
+    
+  let methods_globals (llc:llcontext) (llm:llmodule) (name:string) (m:sailor_method) (globals:t) : t = 
+      let llvm_rt = match m.decl.ret with
+      | Some t -> getLLVMType t llc llm
+      | None -> void_type llc
+      in
+      let args_type = List.map (fun (_,arg) -> getLLVMType arg llc llm) m.decl.args |> Array.of_list in
+      let method_t = function_type llvm_rt args_type in
+      let proto = declare_function name method_t llm
+      in FieldMap.add name {ret=m.decl.ret;proto} globals
+
+
+  let processes_globals (llc:llcontext) (llm:llmodule) (name:string) (p: sailor_process) (globals:t) : t = 
+    let args_type = List.map (fun (_,arg) -> getLLVMType arg llc llm) p.args |> Array.of_list in
+    let process_t  = function_type (void_type llc) args_type in
+    let name' = if String.equal "_Main_" name then "main" else name in
+    let proto = declare_function name' process_t llm in
+    FieldMap.add name {ret=None;proto} globals
+
+  
+  let get_declarations (sc:sailor_callables) llc llm : t = 
+    Logs.debug (fun m -> m "generating llvm declarations");
+    FieldMap.empty 
+    |> fun g -> FieldMap.fold (methods_globals llc llm) sc.methodMap g
+    |> fun g -> FieldMap.fold (processes_globals llc llm) sc.processMap g
+    (* todo : enums & structs *)
+
+
+    let find_declaration g name = 
+      FieldMap.find_opt name g 
+
+
+    let write_declarations (g:t) name = 
+      (* todo : define a format to easily retrieve information *)
+      let filename = name ^ ".sli" in
+      let def_file = open_out filename in
+      FieldMap.iter (fun _ {ret;_} -> output_string def_file (string_of_sailtype ret)) g;
+      close_out def_file 
+end

--- a/bin/compiler/sail_env.ml
+++ b/bin/compiler/sail_env.ml
@@ -1,11 +1,16 @@
 open Llvm
+open Common
+open Globals
+
 
 module type Env = sig
   type t
-  type value
-  val empty : unit -> t
-  val get_var : t -> string -> value
-  val declare_var : t -> string -> value -> t
+  type sailor_value  
+  val empty : Globals.t -> t
+
+  val get_method : t -> string ->  function_value option
+  val get_var : t -> string -> sailtype * sailor_value
+  val declare_var : t -> string -> sailtype * sailor_value -> t
   val print_env : t -> unit
 
 end
@@ -13,7 +18,6 @@ end
 module type StackEnv = 
 sig
   include Env
-
   type frame
   val push_frame :  t -> frame -> t
   val pop_frame : t -> t
@@ -22,57 +26,62 @@ sig
   val current_frame : t -> frame * t
 end
 
-module SailEnv : (StackEnv with type value = llvalue) = 
+module SailEnv : (StackEnv with type sailor_value = llvalue) = 
 struct
-  module M = Map.Make(String)
+  type sailor_value = llvalue
+  type frame = (sailtype * sailor_value) FieldMap.t
+  type t = frame List.t * Globals.t
 
-  type value = llvalue
-  type frame = value M.t
-  type t = frame List.t
+  let empty g = 
+    let c = FieldMap.empty in [c],g
 
-  let empty () = let c = M.empty in [c]
+  let push_frame (env,g) s = 
+    s :: env, g
 
-  let push_frame env s = 
-    s :: env
+  let pop_frame (env,g) = 
+    List.tl env, g
 
-  let pop_frame env = 
-    List.tl env
+  let new_frame e =
+    let c = FieldMap.empty in
+    push_frame e c
 
-  let new_frame env =
-    let c = M.empty in
-    push_frame env c
-
-  let current_frame = function [] -> failwith "environnement is empty !" | h::t ->  h,t
+  let current_frame = function [],_ -> failwith "environnement is empty !" | (h::t),g ->  h,(t,g)
 
   
-  let print_env env =
-    let rec aux env : string = 
+  let print_env (e:t) =
+    let rec aux (env:t) : string = 
       let c,env = current_frame env in
       let p =
-        M.fold 
-          (fun _ v -> let s = Printf.sprintf "%s " (value_name v) in fun n  ->  s ^ n) c "]"
+        FieldMap.fold 
+          (fun _ (_,v) -> let s = Printf.sprintf "%s " (value_name v) in fun n  ->  s ^ n) c "]"
       in let c = "\t[ " ^ p  in
       match env with
-      | [] -> c ^ "\n"
+      | [],_ -> c ^ "\n"
       | _ -> c ^ "\n"  ^ aux env
-    in try
-    Logs.debug (fun m -> m "env : \n{\n %s }" (aux env) )
-    with _ -> ()
-  let get_var env name = 
+    in 
+    try
+    Logs.debug (fun m -> m "env : \n{\n %s }" (aux e) )
+    with _ -> failwith "problem with printing env (env empty?)"
+  
+
+  let get_method (_,g) name =
+    Globals.find_declaration g name
+    
+  let get_var e name : sailtype * llvalue = 
     let rec aux env = 
       let current,env = current_frame env in
-      match M.find_opt name current with 
+      match FieldMap.find_opt name current with 
       | Some v -> v
-      | None  when env = [] ->  Printf.sprintf "variable %s doesn't exists !" name |> failwith
+      | None  when fst env = [] ->  Printf.sprintf "variable %s doesn't exists !" name |> failwith
       | _ -> aux env
-      in aux env
+      in aux e
 
-  let declare_var env name value =
-    let current,env = current_frame env in
-    match M.find_opt name current with 
+  let declare_var e name (tyval:sailtype * llvalue) =
+    let current,_env = current_frame e in
+    match FieldMap.find_opt name current with 
     | Some _ -> Printf.sprintf "variable %s already exists !" name |> failwith
     | None -> 
-      let upd_frame = M.add name value current in
-      push_frame env upd_frame
+      let upd_frame = FieldMap.add name tyval current in
+      push_frame _env upd_frame
 
 end

--- a/bin/compiler/type_checker.ml
+++ b/bin/compiler/type_checker.ml
@@ -1,0 +1,280 @@
+open Common
+open Compiler_common
+open Ast
+
+
+let sailtype_of_literal = function
+  | LBool _ -> Bool
+  | LFloat _ -> Float
+  | LInt _ -> Int
+  | LChar _ -> Char
+  | LString _ -> String
+
+let print_method_proto (name:string) (methd: sailor_method) =
+    let _,args_type = List.split methd.decl.args in
+    let args = String.concat "," (List.map (fun t -> string_of_sailtype (Some t)) args_type) in
+    let methd_string = Printf.sprintf "method %s : %s" name args in
+    Logs.debug (fun m -> m "%s" methd_string)
+
+let print_process_proto (name:string) (proc: sailor_process) =
+  let _,args_type = List.split proc.args in
+  let args = String.concat "," (List.map (fun t -> string_of_sailtype (Some t)) args_type) in
+  let methd_string = Printf.sprintf "process %s : %s" name args in
+  Logs.debug (fun m -> m "%s" methd_string)
+
+let print_callsMap {methodMap; processMap; _} =
+  FieldMap.iter print_method_proto methodMap;
+  FieldMap.iter print_process_proto processMap
+
+
+(* todo : use sail_env *)
+let current_frame = function [] -> failwith "phase1 environnement is empty !" | (h::t) ->  h,t
+
+let push_frame ts s = s :: ts
+
+let pop_frame = function _::t  -> t | [] -> Logs.warn (fun m -> m "popping empty frame"); []
+
+let new_frame ts =
+  let c = FieldMap.empty in
+  push_frame ts c
+
+let get_var e name = 
+  let rec aux env = 
+    let current,next = current_frame env in
+    match FieldMap.find_opt name current with 
+    | Some v -> v
+    | None  when env = [] ->  Printf.sprintf "variable %s doesn't exists !" name |> failwith
+    | _ -> aux next
+    in aux e
+
+let declare_var ts name value =
+  let current,next = current_frame ts in
+  match FieldMap.find_opt name current with 
+  | Some _ -> Printf.sprintf "variable %s already exists !" name |> failwith
+  | None -> 
+    let upd_frame = FieldMap.add name value current in
+    push_frame next upd_frame
+
+(* end todo *)
+
+
+(* do some basic type checking and monomorphize *)
+let analyse_statement (s: Ast.statement) (args: sailtype FieldMap.t) (sm : Ast.statement sailModule) (ext: sailor_externals) (sc:sailor_callables) : sailor_callables =
+  
+  let resolveType (arg: sailtype) (m_param : sailtype) (generics : string list) (resolved_generics: sailor_args) : sailtype * sailor_args =
+    let rec aux (a:sailtype) (m:sailtype) (g:sailor_args) = match (a,m) with
+    | Bool,Bool -> Bool,g
+    | Int,Int -> Int,g
+    | Float,Float -> Float,g
+    | Char,Char -> Char,g
+    | String,String -> String,g
+    | ArrayType at,ArrayType mt -> let t,g = aux at mt g in ArrayType t,g
+    | CompoundType _, CompoundType _ -> failwith "todo"
+    | Box _at, Box _mt -> failwith "todo"
+    | RefType (_at,_am), RefType (_mt,_mm) -> failwith "todo"
+    | GenericType _,_ -> failwith "can't have generic argument"
+    | at,GenericType gt -> 
+      begin
+      if List.mem gt generics then
+        match List.assoc_opt gt g with
+        | None -> at,(gt,at)::g
+        | Some t -> if t = at then at,g else failwith "generic argument mismatch"
+      else
+        failwith "generic argument not declared"
+      end
+    | _ -> Printf.sprintf "wants %s but %s provided" 
+           (string_of_sailtype (Some m))
+           (string_of_sailtype (Some a))
+          |> failwith 
+    in
+    match arg with
+    | GenericType _ -> failwith "can't have generic argument"
+    | _ -> aux arg m_param resolved_generics
+    
+  in
+
+  let check_args (caller_args:sailtype list) (args:sailtype list) (generics : string list) : sailor_args = 
+    if List.length caller_args <> List.length args then
+      failwith "wrong number of arguments";
+      Logs.debug (fun m-> m "caller args : ");
+      List.iter (fun t -> Logs.debug (fun m-> m "%s " (string_of_sailtype (Some t)))) caller_args;
+      Logs.debug (fun m-> m "method args : ");
+      List.iter (fun t -> Logs.debug (fun m-> m "%s " (string_of_sailtype (Some t)))) args;
+
+    List.fold_left2 (
+      fun g ca a -> 
+        resolveType ca a generics g |> snd
+    ) ([]) caller_args args
+  in
+
+  let rec construct_call (calle:string) (el:expression list) (ts : varTypesMap) (sc:sailor_callables) : sailtype option * sailor_callables = 
+    Logs.debug (fun m -> m "found call to %s" calle);
+    
+    (* we construct the types of the args (and collect extra new calls) *)
+    let call_args,sc' = List.fold_left (
+      fun (l,sc) e -> let t,sc' = analyse_expression e ts sc in (t::l,sc')
+    ) ([],sc) el in
+
+    let call_args = List.rev call_args in
+    (* we check if the calle is external *)
+    match List.assoc_opt calle ext with
+    | None -> 
+      begin
+        (* we check if we are calling a method *)
+        let r_type,args,generics,body = match List.find_opt (fun m -> m.m_name = calle) sm.methods with
+        | None -> 
+          (* if not we check if it's a process *)
+            begin
+              match List.find_opt (fun p -> p.p_name = calle) sm.processes with
+              | None ->  calle ^ " is not declared" |> failwith
+              | Some p -> 
+                let g = p.p_interface |> fst in
+                None,g,p.p_generics,p.p_body
+            end
+        | Some m -> m.m_rtype,m.m_params,m.m_generics,m.m_body
+        in
+
+        (* we make sure they correspond to what the callable wants *)
+        (* if the callable is generic we check all the generic types are present at least once *)
+        (* 
+          we build a (string*sailtype) list of generic to type correspondance
+          if the generic is not found in the list, we add it with the corresponding type
+          if the generic already exists with the same type as the new one, we are good else we fail 
+        *)
+
+        let args_name,args_type = List.split args in
+        let resolved_generics = check_args call_args args_type generics in
+        let ret = match r_type with
+        | Some t -> Some (degenerifyType t resolved_generics)
+        | None -> None
+        in
+        let name = mangle_method_name calle call_args in
+        let call : sailor_method = {body; decl={ret; args=(List.combine args_name call_args)}; generics=resolved_generics} in 
+        let methodMap = FieldMap.add name call sc'.methodMap in 
+        ret,{sc' with methodMap}
+      end
+    | Some (decl,generics,_) -> 
+      let arg_types = List.split decl.args |> snd in
+      check_args call_args arg_types generics  |> ignore;
+      decl.ret,sc'
+
+  and analyse_expression (e:expression) (ts : varTypesMap) (sc : sailor_callables) : sailtype * sailor_callables =
+  let rec aux e sc = match e with
+  | Variable s -> get_var ts s, sc
+  | MethodCall (name,el) -> 
+    begin
+      match construct_call name el ts sc with
+      | None,_ -> "trying to use the result of void function " ^ name |> failwith
+      | Some t,sc -> t,sc
+    end
+  | Literal l -> sailtype_of_literal l, sc
+  | StructRead (_,_) -> failwith "todo"
+  | ArrayRead (e,_) -> 
+    begin 
+      match aux e sc with
+      | (ArrayType t,sc) -> t,sc
+      | _ -> failwith "not an array !"
+    end
+  | UnOp (_,e) -> aux e sc
+  | BinOp (_,e1,e2) -> 
+    let t1,sc' = aux e1 sc in let t2,sc' = aux e2 sc' in
+    if t1 <> t2 then failwith "operands do not have the same type !" else t1,sc'
+
+  | Ref (m,e) -> let t,sc' = aux e sc in RefType (t,m),sc'
+  | Deref e -> let t,sc' = aux e sc in
+    begin
+      match t with
+      | RefType _ -> t,sc'
+      | _ -> failwith "can't deref a non-reference!"
+    end
+  | ArrayStatic (e::h) -> 
+    let first_t,sc' = aux e sc in
+    let t,v = List.fold_left (
+      fun (last_t,sc') e -> 
+        let next_t,next_ts = aux e sc' in
+        if next_t <> last_t then failwith "mixed type array !" else (next_t,next_ts)
+    ) (first_t,sc') h in
+    ArrayType t,v
+  | ArrayStatic [] -> failwith "error : empty array"
+  | StructAlloc (_,_) -> failwith "todo"
+  | EnumAlloc (_,_) -> failwith "todo"
+  in aux e sc
+  
+    (*todo : more checks (arrays...) *)
+  and analyse_statement (st:statement) (ts : varTypesMap) (sc : sailor_callables) : varTypesMap * sailor_callables = match st with
+  | Invoke (_,name,el) -> let rt,sc' = construct_call name el ts sc in 
+    if Option.is_some rt then
+      Logs.warn (fun m -> m "result of non-void function %s is discarded" name);
+    ts,sc'
+
+  | DeclVar (_,name,t,None) -> declare_var ts name t,sc
+  | DeclVar (_,name,t,Some e) -> 
+    let t_r,sc' = analyse_expression e ts sc in 
+    if t <> t_r then failwith "type declared and assigned mismatch !"
+    else declare_var ts name t,sc'
+
+  | Block s -> let new_ts,sc' = analyse_statement s (new_frame ts) sc in pop_frame new_ts,sc'
+  | Seq (s1,s2) -> let ts',sc' = analyse_statement s1 ts sc in analyse_statement s2 ts' sc'
+  | Assign (el,er) -> 
+    let t_l,sc_l = analyse_expression el ts sc in
+    let t_r,sc_r = analyse_expression er ts sc_l in 
+    if t_l <> t_r then failwith "type declared and assigned mismatch !" else ts,sc_r
+
+  | If (e,s1, Some s2) -> let sc' = analyse_expression e ts sc |> snd in
+    let sc' = analyse_statement s1 ts sc' |> snd in analyse_statement s2 ts sc'
+
+  | If (e,s, None) -> let sc' = analyse_expression e ts sc |> snd in analyse_statement s ts sc'
+  | While (e,s) -> let sc' = analyse_expression e ts sc |> snd in analyse_statement s ts sc'
+  (* todo : check return type *)
+  | Return Some e -> let sc' = analyse_expression e ts sc |> snd in ts,sc'
+  | Return None -> ts,sc
+  | Loop s -> analyse_statement s ts sc
+  | _ -> ts,sc (* todo : other stuffs *)
+  
+  in 
+  analyse_statement s [args] sc |> snd
+
+
+let method_start_env (m:Ast.statement method_defn) : sailtype FieldMap.t = 
+  let f = fun m (n,t) -> FieldMap.add n t m in
+  List.fold_left f FieldMap.empty m.m_params 
+
+let process_start_env (p:Ast.statement process_defn) : sailtype FieldMap.t = 
+  let f = fun m (n,t) -> FieldMap.add n t m in
+  List.fold_left f FieldMap.empty (fst p.p_interface)
+
+
+let analyse_method (m: Ast.statement method_defn) (sm : Ast.statement sailModule) (ext:sailor_externals) (sc:sailor_callables) : sailor_callables = 
+  let methodMap = 
+    if m.m_generics = [] then
+    (* method isn't generic, we add it *)
+      let name = mangle_method_name m.m_name (List.split m.m_params |> snd) in 
+      let methd = {body=m.m_body; decl={ret=m.m_rtype; args=m.m_params}; generics=[]} in
+      FieldMap.add name methd sc.methodMap
+  else
+    sc.methodMap
+  in
+  analyse_statement m.m_body (method_start_env m) sm ext {sc with methodMap}
+
+let analyse_process (p:Ast.statement process_defn) (sm : Ast.statement sailModule) (ext:sailor_externals) (sc:sailor_callables) : sailor_callables =
+  let processMap = 
+    if p.p_generics = [] then
+      let args = p.p_interface |> fst in 
+    (* process isn't generic, we add it *)
+      let name = mangle_method_name p.p_name (List.split args |> snd) in
+      let proc = {body=p.p_body; args; generics=[]} in
+      FieldMap.add name proc sc.processMap
+    else
+      sc.processMap
+    in
+    analyse_statement p.p_body (process_start_env p) sm ext {sc with processMap}
+
+let type_check_module (a: Ast.statement Common.sailModule) : sailor_callables = 
+  Logs.debug (fun m -> m "analysing types");
+  let externals = Externals.get_externals () in
+  let callables : sailor_callables = { methodMap=FieldMap.empty; processMap=FieldMap.empty }
+  |> fun c -> List.fold_left (fun sc m -> analyse_method m a externals sc) c a.methods
+  |> fun c -> List.fold_left (fun sc p -> analyse_process p a externals sc) c a.processes in
+  Logs.debug (fun m -> m "deduced declarations :");
+  print_callsMap callables;
+  callables


### PR DESCRIPTION
- introduce a type checker that also looks for calls to generic methods and deduces their monomorphic versions
- Passing an array to a method/process works correctly now
- lots of code rework

Here is a sample program to test : 
```
method getMin<T> (a : array<T>, size : int) : T {
 var res : int = 0;
 var cpt : int = 1;
    while (cpt < size) {
        if (a[cpt] < a[res])
            res = cpt;
        cpt = cpt + 1
    }
  return a[res];
}

process Main(){
        var a : array<int> = [6,57,23,2,5,6,7,10,13,5];
        var c : array<float> = [1.5,2.1,6.2, 0.1];


        printf("%i\n", getMin(a,10));
        printf("%f\n", getMin(c,4));
}

```