### PR TITLE
sailor : support arbitrary long numbers

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -3,7 +3,6 @@
     evaluator
     compiler
     ir
-  
     logs.fmt
     cmdliner
     logs

--- a/dune-project
+++ b/dune-project
@@ -23,4 +23,5 @@
     (mtime (>= 1.3.0))
     (ctypes-foreign (>= 0.18.0))
     (llvm (>= 13.0.0))
+    zarith
     ))

--- a/sail-pl.opam
+++ b/sail-pl.opam
@@ -18,6 +18,7 @@ depends: [
   "mtime" {>= "1.3.0"}
   "ctypes-foreign" {>= "0.18.0"}
   "llvm" {>= "13.0.0"}
+  "zarith"
   "odoc" {with-doc}
 ]
 build: [

--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -53,7 +53,7 @@ and eval_r (env:SailEnv.t) (llvm:llvm_args) (x:AstMir.expression) : llvalue =
   match x.exp with
   | Variable _ | StructRead _ | ArrayRead _ | StructAlloc _ ->  let v = eval_l env llvm x in build_load v "" llvm.b
 
-  | Literal l ->  getLLVMLiteral l llvm
+  | Literal l -> getLLVMLiteral l llvm
   | UnOp (op,e) -> let l = eval_r env llvm e in unary op (ty_of_alias ty (snd env),l) llvm.b
   | BinOp (op,e1, e2) -> 
       let l1 = eval_r env llvm e1
@@ -100,7 +100,7 @@ and construct_call (name:string) ((_,mname):l_str) (args:AstMir.expression list)
       List.map2 (fun t v -> 
       let builder =
         match ty_of_alias t (snd env) with
-        | Bool | Int | Char -> build_zext
+        | Bool | Int _ | Char -> build_zext
         | Float -> build_bitcast
         | _ -> build_ptrtoint
         in

--- a/src/codegen/codegenEnv.ml
+++ b/src/codegen/codegenEnv.ml
@@ -30,10 +30,12 @@ module SailEnv = VariableDeclEnv (Declarations)(
 
 open Declarations
 
+
+  
 let getLLVMBasicType f t llc llm  : lltype = 
   let rec aux = function
   | Bool -> i1_type llc
-  | Int -> i32_type llc 
+  | Int n -> integer_type llc n
   | Float -> double_type llc
   | Char -> i8_type llc
   | String -> i8_type llc |> pointer_type

--- a/src/codegen/codegenUtils.ml
+++ b/src/codegen/codegenUtils.ml
@@ -12,10 +12,10 @@ let mangle_method_name (name:string) (mname:string) (args: sailtype list ) : str
   res
 
 
-let getLLVMLiteral (l:literal) (llvm:llvm_args) : llvalue =
+let getLLVMLiteral (l:literal)  (llvm:llvm_args) : llvalue =
   match l with
   | LBool b -> const_int (i1_type llvm.c) (Bool.to_int b)
-  | LInt i -> const_int (i32_type llvm.c) i
+  | LInt i -> const_int_of_string (integer_type llvm.c i.size) (Z.to_string i.l) 10
   | LFloat f -> const_float (double_type llvm.c) f
   | LChar c -> const_int (i8_type llvm.c) (Char.code c)
   | LString s -> build_global_stringptr  s ".str" llvm.b
@@ -35,16 +35,16 @@ let unary (op:unOp) (t,v) : llbuilder -> llvalue =
   let f = 
     match t,op with
     | Float,Neg -> build_fneg
-    | Int,Neg -> build_neg
+    | Int _,Neg -> build_neg
     | _,Not  -> build_not
     | _ -> Printf.sprintf "bad unary operand type : '%s'. Only double and int are supported" (string_of_sailtype (Some t)) |> failwith
   in f v ""
   
   
 let binary (op:binOp) (t:sailtype) (l1:llvalue) (l2:llvalue) : llbuilder -> llvalue = 
-  let operators = [
-    (Int, 
-      [
+  let operators = function
+    | Int _ -> 
+      Some [
         (Minus, build_sub) ; (Plus, build_add) ; (Rem, build_srem) ;
         (Mul,build_mul) ; (Div, build_sdiv) ; 
         (Eq, build_icmp Icmp.Eq) ; (NEq, build_icmp Icmp.Ne) ;
@@ -52,9 +52,8 @@ let binary (op:binOp) (t:sailtype) (l1:llvalue) (l2:llvalue) : llbuilder -> llva
         (Le, build_icmp Icmp.Sle) ; (Ge, build_icmp Icmp.Sge) ;
         (And, build_and) ; (Or, build_or) ;
       ]
-    ) ;
-    (Char, 
-    [
+    | Char ->
+    Some [
       (Minus, build_sub) ; (Plus, build_add) ; (Rem, build_srem) ;
       (Mul,build_mul) ; (Div, build_sdiv) ; 
       (Eq, build_icmp Icmp.Eq) ; (NEq, build_icmp Icmp.Ne) ;
@@ -62,24 +61,23 @@ let binary (op:binOp) (t:sailtype) (l1:llvalue) (l2:llvalue) : llbuilder -> llva
       (Le, build_icmp Icmp.Sle) ; (Ge, build_icmp Icmp.Sge) ;
       (And, build_and) ; (Or, build_or) ;
     ]
-  )
-    ;
-    (Float,
-      [
+  
+    | Float ->
+      Some [
         (Minus, build_fsub) ; (Plus, build_fadd) ; (Rem, build_frem) ;
         (Mul,build_fmul) ; (Div, build_fdiv) ; 
         (Eq, build_fcmp Fcmp.Oeq) ; (NEq, build_fcmp Fcmp.One) ;
         (Lt, build_fcmp Fcmp.Olt) ; (Gt, build_fcmp Fcmp.Ogt) ; 
         (Le, build_fcmp Fcmp.Ole) ; (Ge, build_fcmp Fcmp.Oge) ;
       ]
-    )
-  ] in
+    | _ -> None
+  in
   let string_of_binop = function Minus -> "minus" | Plus -> "plus" | Rem -> "rem" | Eq -> "equal" 
   | And -> "and" | Or -> "or" | Le -> "le" | Lt -> "lt" | Ge -> "ge" | Gt -> "gt" | Mul -> "mul"
   | NEq -> "neq" | Div -> "div"
   in
-  let t = if t = Bool then Int else t in (* thir will have checked for correctness *)
-  let l = List.assoc_opt t operators in
+  let t = if t = Bool then Int 1 else t in (* thir will have checked for correctness *)
+  let l = operators t in
   let open Common.Monad.MonadOperator(Common.MonadOption.M) in
   match l >>| List.assoc_opt op with
   | Some Some oper -> oper l1 l2 ""

--- a/src/common/dune
+++ b/src/common/dune
@@ -1,5 +1,5 @@
 (include_subdirs unqualified)
 
 (library
-(libraries logs menhirLib fmt)
+(libraries logs zarith menhirLib fmt)
  (name common))

--- a/src/common/ppCommon.ml
+++ b/src/common/ppCommon.ml
@@ -33,7 +33,7 @@ let pp_binop pf b =
   let pp_literal (pf : formatter) (c : literal) : unit = 
     match c with 
     | LBool (b) -> Format.fprintf pf "%b" b
-    | LInt (i) -> pp_print_int pf i
+    | LInt i -> pp_print_string pf (Z.to_string i.l)
     | LFloat (f) -> Format.fprintf pf "%f" f
     | LChar (c) -> Format.fprintf pf "\'%s\'" (Char.escaped c)
     | LString s -> Format.fprintf pf "\"%s\"" (String.escaped s)
@@ -43,7 +43,7 @@ let pp_binop pf b =
   let rec pp_type (pf : formatter) (t : sailtype) : unit =
     match t with 
         Bool -> pp_print_string pf "bool"
-      | Int -> pp_print_string pf "int"
+      | Int n ->  Format.fprintf pf "i%i" n
       | Float -> pp_print_string pf "float"
       | Char -> pp_print_string pf "char"
       | String -> pp_print_string pf "string"

--- a/src/common/typesCommon.ml
+++ b/src/common/typesCommon.ml
@@ -52,7 +52,7 @@ let string_of_decl : (_,_,_,_,_) decl_sum -> string = function
 
 type sailtype =
   | Bool 
-  | Int 
+  | Int of int
   | Float 
   | Char 
   | String
@@ -69,7 +69,7 @@ type sailtype =
 
 type literal =
   | LBool of bool
-  | LInt of int
+  | LInt of {l:Z.t;size:int}
   | LFloat of float
   | LChar of char
   | LString of string
@@ -77,7 +77,7 @@ type literal =
 let sailtype_of_literal = function
 | LBool _ -> Bool
 | LFloat _ -> Float
-| LInt _ -> Int
+| LInt l -> Int l.size
 | LChar _ -> Char
 | LString _ -> String
 
@@ -86,7 +86,7 @@ let rec string_of_sailtype (t : sailtype option) : string =
   let open Printf in 
   match t with 
   | Some Bool -> "bool"
-  | Some Int -> "int"
+  | Some Int size -> "i" ^ string_of_int  size
   | Some Float -> "float"
   | Some Char -> "char"
   | Some String -> "string"

--- a/src/evaluator/domain.ml
+++ b/src/evaluator/domain.ml
@@ -56,7 +56,7 @@ type value =
 let valueOfLiteral c =
   match c with
   | LBool x -> VBool x
-  | LInt x -> VInt x
+  | LInt x -> VInt (Z.to_int x.l)
   | LFloat x -> VFloat x
   | LChar x -> VChar x
   | LString x -> VString x

--- a/src/evaluator/externalsInterfaces.ml
+++ b/src/evaluator/externalsInterfaces.ml
@@ -2,7 +2,7 @@ open Common.TypesCommon
 open Common.SailModule
 
 let e_print_string = {pos= dummy_pos;name="print_string"; generics=[];params=[{id="x";mut=false;ty=String; loc=dummy_pos}];variadic=false;rtype=None}
-let e_print_int = {pos= dummy_pos;name="print_int"; generics=[];params=[{id="x";mut=false;ty=Int; loc=dummy_pos}];variadic=false;rtype=None}
+let e_print_int = {pos= dummy_pos;name="print_int"; generics=[];params=[{id="x";mut=false;ty=(Int 32); loc=dummy_pos}];variadic=false;rtype=None}
 
 let e_print_new_line = {pos= dummy_pos;name="print_newline"; generics=[];params=[];variadic=false;rtype=None}
 

--- a/src/ir/misc/mainProcess.ml
+++ b/src/ir/misc/mainProcess.ml
@@ -15,13 +15,13 @@ struct
     let+ p = E.Logger.throw_if_none (E.make dummy_pos @@ "module '" ^ m.md.name ^ "' : no Main process found") 
                                     (List.find_opt (fun p -> p.p_name = "Main") m.processes)
     in
-    let m_proto = {pos=p.p_pos; name="main"; generics = p.p_generics; params = fst p.p_interface; variadic=false; rtype=Some Int} in
+    let m_proto = {pos=p.p_pos; name="main"; generics = p.p_generics; params = fst p.p_interface; variadic=false; rtype=Some (Int 32)} in
     let m_body = 
       let decls,cfg = p.p_body in 
       let b = IrMir.AstMir.BlockMap.find cfg.output cfg.blocks in
       (* hardcode "return 0" at the end *)
       let blocks = IrMir.AstMir.BlockMap.add cfg.output 
-        {b with terminator=Some (Return (Some {info=(dummy_pos,Int); exp=(Literal (LInt 0))}))} cfg.blocks in
+        {b with terminator=Some (Return (Some {info=(dummy_pos,Int 32); exp=(Literal (LInt {l=Z.zero;size=32}))}))} cfg.blocks in
       Either.right (decls,{cfg with blocks})
     in
     {m_proto; m_body}

--- a/src/ir/sailHir/hir.ml
+++ b/src/ir/sailHir/hir.ml
@@ -117,16 +117,16 @@ struct
         let i_id = "_for_i_" ^ var in 
         let arr_length = List.length el in 
 
-        let tab_decl = info,DeclVar (false, arr_id, Some (ArrayType (Int,arr_length)), Some iterable) in
-        let var_decl = info,DeclVar (true, var, Some Int, None) in 
-        let i_decl = info,DeclVar (true, i_id, Some Int, Some (info,(Literal (LInt 0)))) in 
+        let tab_decl = info,DeclVar (false, arr_id, Some (ArrayType (Int 32,arr_length)), Some iterable) in
+        let var_decl = info,DeclVar (true, var, Some (Int 32), None) in 
+        let i_decl = info,DeclVar (true, i_id, Some (Int 32), Some (info,(Literal (LInt {l=Z.zero;size=32})))) in 
 
         let tab = info,Variable arr_id in 
         let var = info,Variable var in
         let i = info,Variable i_id in
         
-        let cond = info,BinOp (Lt, i, (info,Literal (LInt arr_length))) in 
-        let incr = info,Assign (i,(info,BinOp (Plus, i, (info, Literal (LInt 1))))) in
+        let cond = info,BinOp (Lt, i, (info,Literal (LInt {l=Z.of_int arr_length;size=32}))) in 
+        let incr = info,Assign (i,(info,BinOp (Plus, i, (info, Literal (LInt {l=Z.one;size=32}))))) in
         let init = info,Seq ((info,Seq (tab_decl,var_decl)), i_decl) in 
         let vari = info, Assign (var,(info,ArrayRead(tab,i))) in 
 

--- a/src/ir/sailHir/hirUtils.ml
+++ b/src/ir/sailHir/hirUtils.ml
@@ -88,7 +88,7 @@ let follow_type ty env : (sailtype * D.t) E.t =
     | ArrayType (t,n) -> let+ t,path = aux t path in  ArrayType (t,n),path
     | Box t -> let+ t,path = aux t path in Box t,path
     | RefType (t,mut) -> let+ t,path = aux t path in RefType (t,mut),path
-    | Bool | Char | Int | Float | String | GenericType _ as t ->  (* basic type, stop *)
+    | Bool | Char | Int _ | Float | String | GenericType _ as t ->  (* basic type, stop *)
       (* Logs.debug (fun m -> m "'%s' resolves to '%s'" (string_of_sailtype (Some ty)) (string_of_sailtype (Some ty'))); *)
       return (t,path)
   in

--- a/src/ir/sailThir/thirUtils.ml
+++ b/src/ir/sailThir/thirUtils.ml
@@ -15,7 +15,7 @@ type statement = (loc,l_str,expression) AstHir.statement
 let degenerifyType (t: sailtype) (generics: sailtype dict) loc : sailtype ES.t =
   let rec aux = function
   | Bool -> return Bool
-  | Int -> return Int 
+  | Int n -> return (Int n)
   | Float -> return Float
   | Char -> return Char
   | String -> return String
@@ -78,7 +78,7 @@ let matchArgParam (l,arg: loc * sailtype) (m_param : sailtype) (generics : strin
 
     match lt,rt with
     | Left Bool,Left Bool -> return (Bool,g)
-    | Left Int,Left Int -> return (Int,g)
+    | Left (Int i1), Left (Int i2) when i1 = i2 ->  return ((Int  i1),g) 
     | Left Float,Left Float -> return (Float,g)
     | Left Char,Left Char -> return (Char,g)
     | Left String,Left String -> return (String,g)
@@ -155,6 +155,7 @@ let find_function_source (fun_loc:loc) (_var: string option) (name : l_str) (imp
   | M decl ->  
     let _x = fun_loc and _y = el in 
     let+ _ = check_call (snd name) (snd decl) el fun_loc in mname,decl
+
   | _ -> failwith "non method returned" (* cannot happen because we only requested methods *)
 
          (* ES.throw 

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -3,7 +3,7 @@
 
 (library
  (name sailParser)
- (libraries common menhirLib)
+ (libraries common zarith menhirLib)
 )
 
 (ocamllex lexer)


### PR DESCRIPTION
- Support is provided by the Z module of the zarith package
- when writing a literal number, you can add a suffix to tell the compiler what size it will use. no suffix means 32bits

- add int type parameterized by bit length : i32, i64, i128, i69420... (no restriction for now as llvm is able to deal with it)

  idealy, for literals, there should be a type inference so we don't need to specify a suffix when dealing with type different than i32 but for now you must provide it.

- check for out_of_bounds literal

- int literals can have '_' separators : 1_000_000 is now valid