### PR TITLE
Add some PPXes

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -3,7 +3,6 @@
     evaluator
     compiler
     ir
-  
     logs.fmt
     cmdliner
     logs

--- a/bin/dune
+++ b/bin/dune
@@ -10,6 +10,9 @@
     fmt.tty
     fmt.cli
     logs.cli
-    )
+  )
+  (preprocess
+      (pps logs-ppx)
+  )
   (names sailInterpreter sailCompiler)
   (public_names saili sailor))

--- a/dune-project
+++ b/dune-project
@@ -24,4 +24,6 @@
     (ctypes-foreign (>= 0.18.0))
     (llvm (>= 13.0.0))
     zarith
+    ppx_lun
+    logs-ppx
     ))

--- a/dune-project
+++ b/dune-project
@@ -23,4 +23,5 @@
     (mtime (>= 1.3.0))
     (ctypes-foreign (>= 0.18.0))
     (llvm (>= 13.0.0))
+    zarith
     ))

--- a/sail-pl.opam
+++ b/sail-pl.opam
@@ -18,6 +18,7 @@ depends: [
   "mtime" {>= "1.3.0"}
   "ctypes-foreign" {>= "0.18.0"}
   "llvm" {>= "13.0.0"}
+  "zarith"
   "odoc" {with-doc}
 ]
 build: [

--- a/sail-pl.opam
+++ b/sail-pl.opam
@@ -19,6 +19,8 @@ depends: [
   "ctypes-foreign" {>= "0.18.0"}
   "llvm" {>= "13.0.0"}
   "zarith"
+  "ppx_lun"
+  "logs-ppx"
   "odoc" {with-doc}
 ]
 build: [

--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -84,7 +84,7 @@ and construct_call (name:string) ((_,mname):l_str) (args:AstMir.expression list)
   in
   (* let mname = mangle_method_name name origin.mname args_type in  *)
   let mangled_name = "_" ^ mname ^ "_" ^ name in 
-  Logs.debug (fun m -> m "constructing call to %s" name);
+  [%log debug "constructing call to %s" name];
   let llval,ext = match SailEnv.get_decl mangled_name (Specific (mname,Method)) env with 
     | None ->   
       begin

--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -53,7 +53,7 @@ and eval_r (env:SailEnv.t) (llvm:llvm_args) (x:AstMir.expression) : llvalue =
   match x.exp with
   | Variable _ | StructRead _ | ArrayRead _ | StructAlloc _ ->  let v = eval_l env llvm x in build_load v "" llvm.b
 
-  | Literal l ->  getLLVMLiteral l llvm
+  | Literal l -> getLLVMLiteral l llvm
   | UnOp (op,e) -> let l = eval_r env llvm e in unary op (ty_of_alias ty (snd env),l) llvm.b
   | BinOp (op,e1, e2) -> 
       let l1 = eval_r env llvm e1
@@ -100,7 +100,7 @@ and construct_call (name:string) ((_,mname):l_str) (args:AstMir.expression list)
       List.map2 (fun t v -> 
       let builder =
         match ty_of_alias t (snd env) with
-        | Bool | Int | Char -> build_zext
+        | Bool | Int _ | Char -> build_zext
         | Float -> build_bitcast
         | _ -> build_ptrtoint
         in

--- a/src/codegen/codegenEnv.ml
+++ b/src/codegen/codegenEnv.ml
@@ -30,10 +30,12 @@ module SailEnv = VariableDeclEnv (Declarations)(
 
 open Declarations
 
+
+  
 let getLLVMBasicType f t llc llm  : lltype = 
   let rec aux = function
   | Bool -> i1_type llc
-  | Int -> i32_type llc 
+  | Int n -> integer_type llc n
   | Float -> double_type llc
   | Char -> i8_type llc
   | String -> i8_type llc |> pointer_type

--- a/src/codegen/codegenUtils.ml
+++ b/src/codegen/codegenUtils.ml
@@ -8,7 +8,7 @@ let mangle_method_name (name:string) (mname:string) (args: sailtype list ) : str
   let back = List.fold_left (fun s t -> s ^ string_of_sailtype (Some t) ^ "_"  ) "" args in
   let front = "_" ^ mname ^ "_" ^ name ^ "_" in
   let res = front ^ back in
-  (* Logs.debug (fun m -> m "renamed %s to %s" name res); *)
+  (* [%log debug "renamed %s to %s" name res); *)
   res
 
 

--- a/src/codegen/codegenUtils.ml
+++ b/src/codegen/codegenUtils.ml
@@ -12,10 +12,10 @@ let mangle_method_name (name:string) (mname:string) (args: sailtype list ) : str
   res
 
 
-let getLLVMLiteral (l:literal) (llvm:llvm_args) : llvalue =
+let getLLVMLiteral (l:literal)  (llvm:llvm_args) : llvalue =
   match l with
   | LBool b -> const_int (i1_type llvm.c) (Bool.to_int b)
-  | LInt i -> const_int (i32_type llvm.c) i
+  | LInt i -> const_int_of_string (integer_type llvm.c i.size) (Z.to_string i.l) 10
   | LFloat f -> const_float (double_type llvm.c) f
   | LChar c -> const_int (i8_type llvm.c) (Char.code c)
   | LString s -> build_global_stringptr  s ".str" llvm.b
@@ -35,16 +35,16 @@ let unary (op:unOp) (t,v) : llbuilder -> llvalue =
   let f = 
     match t,op with
     | Float,Neg -> build_fneg
-    | Int,Neg -> build_neg
+    | Int _,Neg -> build_neg
     | _,Not  -> build_not
     | _ -> Printf.sprintf "bad unary operand type : '%s'. Only double and int are supported" (string_of_sailtype (Some t)) |> failwith
   in f v ""
   
   
 let binary (op:binOp) (t:sailtype) (l1:llvalue) (l2:llvalue) : llbuilder -> llvalue = 
-  let operators = [
-    (Int, 
-      [
+  let operators = function
+    | Int _ -> 
+      Some [
         (Minus, build_sub) ; (Plus, build_add) ; (Rem, build_srem) ;
         (Mul,build_mul) ; (Div, build_sdiv) ; 
         (Eq, build_icmp Icmp.Eq) ; (NEq, build_icmp Icmp.Ne) ;
@@ -52,9 +52,8 @@ let binary (op:binOp) (t:sailtype) (l1:llvalue) (l2:llvalue) : llbuilder -> llva
         (Le, build_icmp Icmp.Sle) ; (Ge, build_icmp Icmp.Sge) ;
         (And, build_and) ; (Or, build_or) ;
       ]
-    ) ;
-    (Char, 
-    [
+    | Char ->
+    Some [
       (Minus, build_sub) ; (Plus, build_add) ; (Rem, build_srem) ;
       (Mul,build_mul) ; (Div, build_sdiv) ; 
       (Eq, build_icmp Icmp.Eq) ; (NEq, build_icmp Icmp.Ne) ;
@@ -62,24 +61,23 @@ let binary (op:binOp) (t:sailtype) (l1:llvalue) (l2:llvalue) : llbuilder -> llva
       (Le, build_icmp Icmp.Sle) ; (Ge, build_icmp Icmp.Sge) ;
       (And, build_and) ; (Or, build_or) ;
     ]
-  )
-    ;
-    (Float,
-      [
+  
+    | Float ->
+      Some [
         (Minus, build_fsub) ; (Plus, build_fadd) ; (Rem, build_frem) ;
         (Mul,build_fmul) ; (Div, build_fdiv) ; 
         (Eq, build_fcmp Fcmp.Oeq) ; (NEq, build_fcmp Fcmp.One) ;
         (Lt, build_fcmp Fcmp.Olt) ; (Gt, build_fcmp Fcmp.Ogt) ; 
         (Le, build_fcmp Fcmp.Ole) ; (Ge, build_fcmp Fcmp.Oge) ;
       ]
-    )
-  ] in
+    | _ -> None
+  in
   let string_of_binop = function Minus -> "minus" | Plus -> "plus" | Rem -> "rem" | Eq -> "equal" 
   | And -> "and" | Or -> "or" | Le -> "le" | Lt -> "lt" | Ge -> "ge" | Gt -> "gt" | Mul -> "mul"
   | NEq -> "neq" | Div -> "div"
   in
-  let t = if t = Bool then Int else t in (* thir will have checked for correctness *)
-  let l = List.assoc_opt t operators in
+  let t = if t = Bool then Int 1 else t in (* thir will have checked for correctness *)
+  let l = operators t in
   let open Common.Monad.MonadOperator(Common.MonadOption.M) in
   match l >>| List.assoc_opt op with
   | Some Some oper -> oper l1 l2 ""

--- a/src/codegen/dune
+++ b/src/codegen/dune
@@ -1,3 +1,6 @@
 (library
  (libraries common logs ir sailParser llvm llvm.analysis llvm.executionengine llvm.scalar_opts llvm.ipo llvm.all_backends)
+ (preprocess
+     (pps logs-ppx)
+ )
  (name compiler))

--- a/src/common/dune
+++ b/src/common/dune
@@ -1,5 +1,5 @@
 (include_subdirs unqualified)
 
 (library
-(libraries logs menhirLib fmt)
+(libraries logs zarith menhirLib fmt)
  (name common))

--- a/src/common/ppCommon.ml
+++ b/src/common/ppCommon.ml
@@ -33,7 +33,7 @@ let pp_binop pf b =
   let pp_literal (pf : formatter) (c : literal) : unit = 
     match c with 
     | LBool (b) -> Format.fprintf pf "%b" b
-    | LInt (i) -> pp_print_int pf i
+    | LInt i -> pp_print_string pf (Z.to_string i.l)
     | LFloat (f) -> Format.fprintf pf "%f" f
     | LChar (c) -> Format.fprintf pf "\'%s\'" (Char.escaped c)
     | LString s -> Format.fprintf pf "\"%s\"" (String.escaped s)
@@ -43,7 +43,7 @@ let pp_binop pf b =
   let rec pp_type (pf : formatter) (t : sailtype) : unit =
     match t with 
         Bool -> pp_print_string pf "bool"
-      | Int -> pp_print_string pf "int"
+      | Int n ->  Format.fprintf pf "i%i" n
       | Float -> pp_print_string pf "float"
       | Char -> pp_print_string pf "char"
       | String -> pp_print_string pf "string"

--- a/src/common/typesCommon.ml
+++ b/src/common/typesCommon.ml
@@ -52,7 +52,7 @@ let string_of_decl : (_,_,_,_,_) decl_sum -> string = function
 
 type sailtype =
   | Bool 
-  | Int 
+  | Int of int
   | Float 
   | Char 
   | String
@@ -69,7 +69,7 @@ type sailtype =
 
 type literal =
   | LBool of bool
-  | LInt of int
+  | LInt of {l:Z.t;size:int}
   | LFloat of float
   | LChar of char
   | LString of string
@@ -77,7 +77,7 @@ type literal =
 let sailtype_of_literal = function
 | LBool _ -> Bool
 | LFloat _ -> Float
-| LInt _ -> Int
+| LInt l -> Int l.size
 | LChar _ -> Char
 | LString _ -> String
 
@@ -86,7 +86,7 @@ let rec string_of_sailtype (t : sailtype option) : string =
   let open Printf in 
   match t with 
   | Some Bool -> "bool"
-  | Some Int -> "int"
+  | Some Int size -> "i" ^ string_of_int  size
   | Some Float -> "float"
   | Some Char -> "char"
   | Some String -> "string"

--- a/src/common/typesCommon.ml
+++ b/src/common/typesCommon.ml
@@ -20,6 +20,7 @@
 (* along with this program.  If not, see <https://www.gnu.org/licenses/>. *)
 (**************************************************************************)
 
+module Log = Logs
 module FieldMap = Map.Make (String)
 module FieldSet = Set.Make (String)
 

--- a/src/evaluator/domain.ml
+++ b/src/evaluator/domain.ml
@@ -56,7 +56,7 @@ type value =
 let valueOfLiteral c =
   match c with
   | LBool x -> VBool x
-  | LInt x -> VInt x
+  | LInt x -> VInt (Z.to_int x.l)
   | LFloat x -> VFloat x
   | LChar x -> VChar x
   | LString x -> VString x

--- a/src/evaluator/externalsInterfaces.ml
+++ b/src/evaluator/externalsInterfaces.ml
@@ -2,7 +2,7 @@ open Common.TypesCommon
 open Common.SailModule
 
 let e_print_string = {pos= dummy_pos;name="print_string"; generics=[];params=[{id="x";mut=false;ty=String; loc=dummy_pos}];variadic=false;rtype=None}
-let e_print_int = {pos= dummy_pos;name="print_int"; generics=[];params=[{id="x";mut=false;ty=Int; loc=dummy_pos}];variadic=false;rtype=None}
+let e_print_int = {pos= dummy_pos;name="print_int"; generics=[];params=[{id="x";mut=false;ty=(Int 32); loc=dummy_pos}];variadic=false;rtype=None}
 
 let e_print_new_line = {pos= dummy_pos;name="print_newline"; generics=[];params=[];variadic=false;rtype=None}
 

--- a/src/ir/misc/dune
+++ b/src/ir/misc/dune
@@ -1,3 +1,6 @@
 (library
+  (preprocess
+      (pps logs-ppx)
+  )
  (libraries irThir irMir common)
  (name irMisc))

--- a/src/ir/misc/imports.ml
+++ b/src/ir/misc/imports.ml
@@ -1,7 +1,6 @@
 open Common
 open TypesCommon
 open IrMir
-
 module E = Common.Error
 open Monad.MonadSyntax(E.Logger)
 open Monad.MonadFunctions(E.Logger)
@@ -14,7 +13,7 @@ module Pass = Pass.Make( struct
 
   let read_imports (imports : ImportSet.t) : (string * in_body SailModule.t) list  = 
     List.map (fun i ->  
-      Logs.debug (fun m -> m "reading mir for import '%s' (%s)" i.mname i.dir); 
+      [%log debug "reading mir for import '%s' (%s)" i.mname i.dir]; 
       i.dir,In_channel.with_open_bin (i.dir ^ i.mname ^ Constants.mir_file_ext) Marshal.from_channel
     ) (ImportSet.elements imports)
 
@@ -49,7 +48,7 @@ module Pass = Pass.Make( struct
     {m with methods ; imports; md={m.md with libs}}
 
   let transform (smdl : in_body SailModule.t)  : out_body SailModule.t E.Logger.t =
-    Logs.debug (fun m -> m "imports : %s" (String.concat " " (List.map (fun i -> i.mname) (ImportSet.elements smdl.imports))));
+    [%log debug "imports : %s" (String.concat " " (List.map (fun i -> i.mname) (ImportSet.elements smdl.imports)))];
     set_fcall_source smdl
 end
 )

--- a/src/ir/misc/mainProcess.ml
+++ b/src/ir/misc/mainProcess.ml
@@ -15,13 +15,13 @@ struct
     let+ p = E.Logger.throw_if_none (E.make dummy_pos @@ "module '" ^ m.md.name ^ "' : no Main process found") 
                                     (List.find_opt (fun p -> p.p_name = "Main") m.processes)
     in
-    let m_proto = {pos=p.p_pos; name="main"; generics = p.p_generics; params = fst p.p_interface; variadic=false; rtype=Some Int} in
+    let m_proto = {pos=p.p_pos; name="main"; generics = p.p_generics; params = fst p.p_interface; variadic=false; rtype=Some (Int 32)} in
     let m_body = 
       let decls,cfg = p.p_body in 
       let b = IrMir.AstMir.BlockMap.find cfg.output cfg.blocks in
       (* hardcode "return 0" at the end *)
       let blocks = IrMir.AstMir.BlockMap.add cfg.output 
-        {b with terminator=Some (Return (Some {info=(dummy_pos,Int); exp=(Literal (LInt 0))}))} cfg.blocks in
+        {b with terminator=Some (Return (Some {info=(dummy_pos,Int 32); exp=(Literal (LInt {l=Z.zero;size=32}))}))} cfg.blocks in
       Either.right (decls,{cfg with blocks})
     in
     {m_proto; m_body}

--- a/src/ir/sailHir/hir.ml
+++ b/src/ir/sailHir/hir.ml
@@ -269,7 +269,7 @@ struct
         let* declEnv = ES.get_env in   
         let+ () = SEnv.iter (fun (id,proto) -> check_non_cyclic_struct id proto declEnv |> ES.S.lift) (get_own_decls declEnv |> get_decls Struct) in
 
-        (* Logs.debug (fun m -> m "%s" @@ string_of_declarations declEnv); *)
+        (* [%log debug "%s" @@ string_of_declarations declEnv); *)
         {sm with methods; processes; declEnv}
       ) sm.declEnv |> fst in
       sm

--- a/src/ir/sailHir/hir.ml
+++ b/src/ir/sailHir/hir.ml
@@ -117,16 +117,16 @@ struct
         let i_id = "_for_i_" ^ var in 
         let arr_length = List.length el in 
 
-        let tab_decl = info,DeclVar (false, arr_id, Some (ArrayType (Int,arr_length)), Some iterable) in
-        let var_decl = info,DeclVar (true, var, Some Int, None) in 
-        let i_decl = info,DeclVar (true, i_id, Some Int, Some (info,(Literal (LInt 0)))) in 
+        let tab_decl = info,DeclVar (false, arr_id, Some (ArrayType (Int 32,arr_length)), Some iterable) in
+        let var_decl = info,DeclVar (true, var, Some (Int 32), None) in 
+        let i_decl = info,DeclVar (true, i_id, Some (Int 32), Some (info,(Literal (LInt {l=Z.zero;size=32})))) in 
 
         let tab = info,Variable arr_id in 
         let var = info,Variable var in
         let i = info,Variable i_id in
         
-        let cond = info,BinOp (Lt, i, (info,Literal (LInt arr_length))) in 
-        let incr = info,Assign (i,(info,BinOp (Plus, i, (info, Literal (LInt 1))))) in
+        let cond = info,BinOp (Lt, i, (info,Literal (LInt {l=Z.of_int arr_length;size=32}))) in 
+        let incr = info,Assign (i,(info,BinOp (Plus, i, (info, Literal (LInt {l=Z.one;size=32}))))) in
         let init = info,Seq ((info,Seq (tab_decl,var_decl)), i_decl) in 
         let vari = info, Assign (var,(info,ArrayRead(tab,i))) in 
 

--- a/src/ir/sailHir/hirUtils.ml
+++ b/src/ir/sailHir/hirUtils.ml
@@ -88,7 +88,7 @@ let follow_type ty env : (sailtype * D.t) E.t =
     | ArrayType (t,n) -> let+ t,path = aux t path in  ArrayType (t,n),path
     | Box t -> let+ t,path = aux t path in Box t,path
     | RefType (t,mut) -> let+ t,path = aux t path in RefType (t,mut),path
-    | Bool | Char | Int | Float | String | GenericType _ as t ->  (* basic type, stop *)
+    | Bool | Char | Int _ | Float | String | GenericType _ as t ->  (* basic type, stop *)
       (* Logs.debug (fun m -> m "'%s' resolves to '%s'" (string_of_sailtype (Some ty)) (string_of_sailtype (Some ty'))); *)
       return (t,path)
   in

--- a/src/ir/sailHir/hirUtils.ml
+++ b/src/ir/sailHir/hirUtils.ml
@@ -42,7 +42,7 @@ match import with
     let decl = D.find_decl id (All (Filter filt)) env in
     match decl with
     | [i,m] -> 
-      (* Logs.debug (fun m -> m "'%s' is from %s" id i.mname); *)
+      (* [%log debug "'%s' is from %s" id i.mname); *)
       return ((dummy_pos,i.mname),m)
 
     | [] ->  E.throw @@ Error.make loc @@ "unknown declaration " ^ id
@@ -57,10 +57,10 @@ let follow_type ty env : (sailtype * D.t) E.t =
   
   let current = SailModule.DeclEnv.get_name env in
 
-  (* Logs.debug (fun m -> m "following type '%s'" (string_of_sailtype (Some ty))); *)
+  (* [%log debug "following type '%s'" (string_of_sailtype (Some ty))); *)
 
   let rec aux ty' path : (sailtype * ty_defn list) E.t = 
-    (* Logs.debug (fun m -> m "path: %s" (List.map (fun ({name;_}:ty_defn) -> name)path |> String.concat " ")); *)
+    (* [%log debug "path: %s" (List.map (fun ({name;_}:ty_defn) -> name)path |> String.concat " ")); *)
     match ty' with 
     | CompoundType {origin;name=id;generic_instances;_} -> (* compound type, find location and definition *) 
       let* (l,origin),def = find_symbol_source id origin env in 
@@ -79,7 +79,7 @@ let follow_type ty env : (sailtype * D.t) E.t =
             >>= (fun () -> aux ty (def::path))
             )
           | None -> (* abstract type *) 
-            (* Logs.debug (fun m -> m "'%s' resolves to abstract type '%s' " (string_of_sailtype (Some ty)) def.name);  *)
+            (* [%log debug "'%s' resolves to abstract type '%s' " (string_of_sailtype (Some ty)) def.name);  *)
             return (default (T ()),path)
           end
         | _ -> 
@@ -89,7 +89,7 @@ let follow_type ty env : (sailtype * D.t) E.t =
     | Box t -> let+ t,path = aux t path in Box t,path
     | RefType (t,mut) -> let+ t,path = aux t path in RefType (t,mut),path
     | Bool | Char | Int _ | Float | String | GenericType _ as t ->  (* basic type, stop *)
-      (* Logs.debug (fun m -> m "'%s' resolves to '%s'" (string_of_sailtype (Some ty)) (string_of_sailtype (Some ty'))); *)
+      (* [%log debug "'%s' resolves to '%s'" (string_of_sailtype (Some ty)) (string_of_sailtype (Some ty'))); *)
       return (t,path)
   in
   let+ res,p = aux ty [] in

--- a/src/ir/sailMir/dune
+++ b/src/ir/sailMir/dune
@@ -1,3 +1,6 @@
 (library
  (libraries irThir common)
+   (preprocess
+      (pps logs-ppx)
+  )
  (name irMir))

--- a/src/ir/sailMir/mir.ml
+++ b/src/ir/sailMir/mir.ml
@@ -67,7 +67,7 @@ struct
       if Option.is_some ret && decl.ret <> None then 
         E.log @@ Error.make (Option.get ret) @@ Printf.sprintf "%s doesn't always return !" decl.name
       else
-        let () = BlockMap.iter (fun lbl {location=_;_} ->  Logs.debug (fun m -> m "unreachable block %i" lbl)) unreachable_blocks in
+        let () = BlockMap.iter (fun lbl {location=_;_} ->  [%log debug "unreachable block %i" lbl]) unreachable_blocks in
         try 
           let _,bb = BlockMap.filter (fun _ {location;_} -> location <> dummy_pos) unreachable_blocks |> BlockMap.choose in
           let _loc = match List.nth_opt bb.assignments 0 with
@@ -179,7 +179,7 @@ struct
         res
 
     in 
-    Logs.debug (fun m -> m "lowering to MIR %s" decl.name);
+    [%log debug "lowering to MIR %s" decl.name];
 
     let* (res,_),_env = aux decl.body 0 (fst env) in 
     
@@ -189,7 +189,7 @@ struct
 
     BlockMap.iter (
       fun l bb -> match bb.terminator with 
-      | Some (Return _) -> (* Logs.debug (fun m -> m "found leaf at %i" l); *) reverse_traversal l cfg.blocks |> ignore 
+      | Some (Return _) -> (* [%log debug "found leaf at %i" l); *) reverse_traversal l cfg.blocks |> ignore 
       | _ -> ()
     ) cfg.blocks;
     res,(snd env)

--- a/src/ir/sailMir/mirUtils.ml
+++ b/src/ir/sailMir/mirUtils.ml
@@ -230,7 +230,7 @@ let reverse_traversal (lbl:int) (blocks : basicBlock BlockMap.t) :  basicBlock B
     let blocks' = BlockMap.remove lbl blocks in
     
     (* if blocks' != blocks then
-      Logs.debug (fun m -> m "reverse bb %i" lbl); *)
+      [%log debug "reverse bb %i" lbl); *)
 
     match BlockMap.find_opt lbl blocks with
     | None -> blocks'
@@ -249,7 +249,7 @@ let cfg_returns ({input;blocks;_} : cfg) : (loc option * basicBlock BlockMap.t) 
 
     (* 
     if blocks' != blocks then
-      Logs.debug (fun m -> m "checking bb %i" lbl);
+      [%log debug "checking bb %i" lbl);
     *) 
     
     match BlockMap.find_opt lbl blocks with

--- a/src/ir/sailThir/thirUtils.ml
+++ b/src/ir/sailThir/thirUtils.ml
@@ -15,7 +15,7 @@ type statement = (loc,l_str,expression) AstHir.statement
 let degenerifyType (t: sailtype) (generics: sailtype dict) loc : sailtype ES.t =
   let rec aux = function
   | Bool -> return Bool
-  | Int -> return Int 
+  | Int n -> return (Int n)
   | Float -> return Float
   | Char -> return Char
   | String -> return String
@@ -78,7 +78,7 @@ let matchArgParam (l,arg: loc * sailtype) (m_param : sailtype) (generics : strin
 
     match lt,rt with
     | Left Bool,Left Bool -> return (Bool,g)
-    | Left Int,Left Int -> return (Int,g)
+    | Left (Int i1), Left (Int i2) when i1 = i2 ->  return ((Int  i1),g) 
     | Left Float,Left Float -> return (Float,g)
     | Left Char,Left Char -> return (Char,g)
     | Left String,Left String -> return (String,g)
@@ -155,6 +155,7 @@ let find_function_source (fun_loc:loc) (_var: string option) (name : l_str) (imp
   | M decl ->  
     let _x = fun_loc and _y = el in 
     let+ _ = check_call (snd name) (snd decl) el fun_loc in mname,decl
+
   | _ -> failwith "non method returned" (* cannot happen because we only requested methods *)
 
          (* ES.throw 

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -3,7 +3,7 @@
 
 (library
  (name sailParser)
- (libraries common menhirLib)
+ (libraries common zarith menhirLib)
 )
 
 (ocamllex lexer)

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -4,6 +4,9 @@
 (library
  (name sailParser)
  (libraries common zarith menhirLib)
+  (preprocess
+      (pps logs-ppx)
+  )
 )
 
 (ocamllex lexer)

--- a/src/parsing/parsing.ml
+++ b/src/parsing/parsing.ml
@@ -8,7 +8,6 @@ open TypesCommon
 module L = MenhirLib.LexerUtil
 module E = MenhirLib.ErrorReports
 
-
 let print_error_position lexbuf =
   let pos = lexbuf.lex_curr_p in
   Printf.sprintf "Line:%d Position:%d" pos.pos_lnum (pos.pos_cnum - pos.pos_bol + 1)
@@ -71,7 +70,7 @@ let fail text buffer (checkpoint : _ I.checkpoint) =
   try
   let message = ParserMessages.message state_num in
   let message = E.expand (get text checkpoint) message in
-  Logs.debug (fun m -> m "reached error state %i "state_num);
+  [%log debug "reached error state %i " state_num];
   Logger.throw @@ Error.make location message
   with Not_found -> 
     Logger.throw @@ Error.make location "Syntax error"


### PR DESCRIPTION
This aims at removing some boilerplate code by bringing mostly dependency-free PPX rewriters, maybe create one for our needs as well. As they are an AST to AST transformation, we can pretty-print it back to a PPX-free code to feed it to coq-of-ocaml for the long-term goal of proving the compiler using Coq.

Interesting PPXes : 

- ppx_lun
- logs_ppx
- ppx_curried_constr 